### PR TITLE
Add option to ignore hidden files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ Install
 Usage
 -----
 
-**dirtree(dir[, label], cb)**
+**dirtree(dir[, opts], cb)**
 
 - `dir` `<String>` root directory path
-- `label` `<String>` *(optional)* label for the root node of the directory tree; if nothing specified, the root path's basename will be used.
+- `opts` `<Object>` *(optional)* object with the following properties:
+  - `label` `<String>` label for the root node of the directory tree; if nothing specified, the root path's basename will be used.
+  - `hidden` `<Boolean>` determines if hidden files should be included; set to false to ignore hidden files; defaults to true.
 - `cb` `<Function>`
   - `err` `<Error | null>`
   - `dirtree` `<String>` string representation of the directory structure
@@ -39,7 +41,7 @@ dirTree('some/dir', (err, tr) => {
 ```js
 const dirTree = require('dir-tree-creator')
 
-dirTree('some/dir', 'custom label', (err, tr) => {
+dirTree('some/dir', { label: 'custom label' }, (err, tr) => {
   if (err) return console.error(err)
   console.log(tr)
 })
@@ -55,8 +57,7 @@ custom label
 ├─┬ dir1
 │ ├─┬ dir2  
 │ │ └── file2.js  
-│ └── file1.md 
+│ └── file1.md
 ├── file-under-root.js
 └── .gitignore  
 ```
-

--- a/test/test.js
+++ b/test/test.js
@@ -52,10 +52,47 @@ describe('dir-tree-creator', () => {
     └─┬ dir333
       └── f4`
 
-    dirTree(testDir, 'custom-label', (er, tr) => {
+    dirTree(testDir, { label: 'custom-label' }, (er, tr) => {
       if (er) assert.ifError(er)
       assert.strictEqual(tr, wanted)
       done()
     })
   })
+
+  // TODO: Rewrite test to also work on Windows systems. For now it doesn't
+  // run if testing on Windows.
+  if (process.platform !== 'win32') {
+    it('should return string representation of dir tree structure - no hidden files', done => {
+      fs.ensureFileSync(path.join(testDir, 'dir1', 'f1'))
+      fs.ensureFileSync(path.join(testDir, 'dir2', 'dir22', 'f2'))
+      fs.ensureFileSync(path.join(testDir, 'dir2', 'dir22', 'f3'))
+      fs.ensureFileSync(path.join(testDir, 'dir3', 'dir33', 'dir333', 'f4'))
+      fs.ensureFileSync(path.join(testDir, '.dir4', 'f5'))
+      fs.ensureFileSync(path.join(testDir, '.dir5', '.f6'))
+      fs.ensureFileSync(path.join(testDir, 'dir6', '.f7'))
+      fs.ensureFileSync(path.join(testDir, 'dir6', 'f8'))
+      fs.ensureFileSync(path.join(testDir, 'dir7', '.dir77', 'f9'))
+
+      const wanted = `dir-tree-creator
+├─┬ dir1
+│ └── f1
+├─┬ dir2
+│ └─┬ dir22
+│   ├── f2
+│   └── f3
+├─┬ dir3
+│ └─┬ dir33
+│   └─┬ dir333
+│     └── f4
+├─┬ dir6
+│ └── f8
+└── dir7`
+
+      dirTree(testDir, { hidden: false }, (er, tr) => {
+        if (er) assert.ifError(er)
+        assert.strictEqual(tr, wanted)
+        done()
+      })
+    })
+  }
 })


### PR DESCRIPTION
I'm using your module to log the files on all of my external hard drives, and it works great! The only issue is that I don't want to log hidden files, and some of my drives have TONS of them. I figured it would be nice to have the option to hide those.

Not sure if you're accepting contributions, but here are my changes if so.